### PR TITLE
Camel sample

### DIFF
--- a/addons/README.md
+++ b/addons/README.md
@@ -7,6 +7,7 @@ typical use case in test class(es).
 
 | Sample | Directory | Demonstrated feature(s) |
 |---|---|---|
+| Camel | [camel](https://github.com/seedstack/samples/tree/master/addons/camel) | Apache Camel integration |
 | Spring batch | [spring-batch](https://github.com/seedstack/samples/tree/master/addons/spring-batch) | Spring Batch integration |
 | Spring bridge | [spring-bridge](https://github.com/seedstack/samples/tree/master/addons/spring-bridge) | Injection bridge between SeedStack and Spring |
 | W20 bridge | [w20-bridge](https://github.com/seedstack/samples/tree/master/addons/w20-bridge) | Automatic integration of [W20](https://w20-framework.github.io/) frontend framework |

--- a/addons/camel/LICENSE
+++ b/addons/camel/LICENSE
@@ -1,0 +1,373 @@
+Mozilla Public License Version 2.0
+==================================
+
+1. Definitions
+--------------
+
+1.1. "Contributor"
+    means each individual or legal entity that creates, contributes to
+    the creation of, or owns Covered Software.
+
+1.2. "Contributor Version"
+    means the combination of the Contributions of others (if any) used
+    by a Contributor and that particular Contributor's Contribution.
+
+1.3. "Contribution"
+    means Covered Software of a particular Contributor.
+
+1.4. "Covered Software"
+    means Source Code Form to which the initial Contributor has attached
+    the notice in Exhibit A, the Executable Form of such Source Code
+    Form, and Modifications of such Source Code Form, in each case
+    including portions thereof.
+
+1.5. "Incompatible With Secondary Licenses"
+    means
+
+    (a) that the initial Contributor has attached the notice described
+        in Exhibit B to the Covered Software; or
+
+    (b) that the Covered Software was made available under the terms of
+        version 1.1 or earlier of the License, but not also under the
+        terms of a Secondary License.
+
+1.6. "Executable Form"
+    means any form of the work other than Source Code Form.
+
+1.7. "Larger Work"
+    means a work that combines Covered Software with other material, in
+    a separate file or files, that is not Covered Software.
+
+1.8. "License"
+    means this document.
+
+1.9. "Licensable"
+    means having the right to grant, to the maximum extent possible,
+    whether at the time of the initial grant or subsequently, any and
+    all of the rights conveyed by this License.
+
+1.10. "Modifications"
+    means any of the following:
+
+    (a) any file in Source Code Form that results from an addition to,
+        deletion from, or modification of the contents of Covered
+        Software; or
+
+    (b) any new file in Source Code Form that contains any Covered
+        Software.
+
+1.11. "Patent Claims" of a Contributor
+    means any patent claim(s), including without limitation, method,
+    process, and apparatus claims, in any patent Licensable by such
+    Contributor that would be infringed, but for the grant of the
+    License, by the making, using, selling, offering for sale, having
+    made, import, or transfer of either its Contributions or its
+    Contributor Version.
+
+1.12. "Secondary License"
+    means either the GNU General Public License, Version 2.0, the GNU
+    Lesser General Public License, Version 2.1, the GNU Affero General
+    Public License, Version 3.0, or any later versions of those
+    licenses.
+
+1.13. "Source Code Form"
+    means the form of the work preferred for making modifications.
+
+1.14. "You" (or "Your")
+    means an individual or a legal entity exercising rights under this
+    License. For legal entities, "You" includes any entity that
+    controls, is controlled by, or is under common control with You. For
+    purposes of this definition, "control" means (a) the power, direct
+    or indirect, to cause the direction or management of such entity,
+    whether by contract or otherwise, or (b) ownership of more than
+    fifty percent (50%) of the outstanding shares or beneficial
+    ownership of such entity.
+
+2. License Grants and Conditions
+--------------------------------
+
+2.1. Grants
+
+Each Contributor hereby grants You a world-wide, royalty-free,
+non-exclusive license:
+
+(a) under intellectual property rights (other than patent or trademark)
+    Licensable by such Contributor to use, reproduce, make available,
+    modify, display, perform, distribute, and otherwise exploit its
+    Contributions, either on an unmodified basis, with Modifications, or
+    as part of a Larger Work; and
+
+(b) under Patent Claims of such Contributor to make, use, sell, offer
+    for sale, have made, import, and otherwise transfer either its
+    Contributions or its Contributor Version.
+
+2.2. Effective Date
+
+The licenses granted in Section 2.1 with respect to any Contribution
+become effective for each Contribution on the date the Contributor first
+distributes such Contribution.
+
+2.3. Limitations on Grant Scope
+
+The licenses granted in this Section 2 are the only rights granted under
+this License. No additional rights or licenses will be implied from the
+distribution or licensing of Covered Software under this License.
+Notwithstanding Section 2.1(b) above, no patent license is granted by a
+Contributor:
+
+(a) for any code that a Contributor has removed from Covered Software;
+    or
+
+(b) for infringements caused by: (i) Your and any other third party's
+    modifications of Covered Software, or (ii) the combination of its
+    Contributions with other software (except as part of its Contributor
+    Version); or
+
+(c) under Patent Claims infringed by Covered Software in the absence of
+    its Contributions.
+
+This License does not grant any rights in the trademarks, service marks,
+or logos of any Contributor (except as may be necessary to comply with
+the notice requirements in Section 3.4).
+
+2.4. Subsequent Licenses
+
+No Contributor makes additional grants as a result of Your choice to
+distribute the Covered Software under a subsequent version of this
+License (see Section 10.2) or under the terms of a Secondary License (if
+permitted under the terms of Section 3.3).
+
+2.5. Representation
+
+Each Contributor represents that the Contributor believes its
+Contributions are its original creation(s) or it has sufficient rights
+to grant the rights to its Contributions conveyed by this License.
+
+2.6. Fair Use
+
+This License is not intended to limit any rights You have under
+applicable copyright doctrines of fair use, fair dealing, or other
+equivalents.
+
+2.7. Conditions
+
+Sections 3.1, 3.2, 3.3, and 3.4 are conditions of the licenses granted
+in Section 2.1.
+
+3. Responsibilities
+-------------------
+
+3.1. Distribution of Source Form
+
+All distribution of Covered Software in Source Code Form, including any
+Modifications that You create or to which You contribute, must be under
+the terms of this License. You must inform recipients that the Source
+Code Form of the Covered Software is governed by the terms of this
+License, and how they can obtain a copy of this License. You may not
+attempt to alter or restrict the recipients' rights in the Source Code
+Form.
+
+3.2. Distribution of Executable Form
+
+If You distribute Covered Software in Executable Form then:
+
+(a) such Covered Software must also be made available in Source Code
+    Form, as described in Section 3.1, and You must inform recipients of
+    the Executable Form how they can obtain a copy of such Source Code
+    Form by reasonable means in a timely manner, at a charge no more
+    than the cost of distribution to the recipient; and
+
+(b) You may distribute such Executable Form under the terms of this
+    License, or sublicense it under different terms, provided that the
+    license for the Executable Form does not attempt to limit or alter
+    the recipients' rights in the Source Code Form under this License.
+
+3.3. Distribution of a Larger Work
+
+You may create and distribute a Larger Work under terms of Your choice,
+provided that You also comply with the requirements of this License for
+the Covered Software. If the Larger Work is a combination of Covered
+Software with a work governed by one or more Secondary Licenses, and the
+Covered Software is not Incompatible With Secondary Licenses, this
+License permits You to additionally distribute such Covered Software
+under the terms of such Secondary License(s), so that the recipient of
+the Larger Work may, at their option, further distribute the Covered
+Software under the terms of either this License or such Secondary
+License(s).
+
+3.4. Notices
+
+You may not remove or alter the substance of any license notices
+(including copyright notices, patent notices, disclaimers of warranty,
+or limitations of liability) contained within the Source Code Form of
+the Covered Software, except that You may alter any license notices to
+the extent required to remedy known factual inaccuracies.
+
+3.5. Application of Additional Terms
+
+You may choose to offer, and to charge a fee for, warranty, support,
+indemnity or liability obligations to one or more recipients of Covered
+Software. However, You may do so only on Your own behalf, and not on
+behalf of any Contributor. You must make it absolutely clear that any
+such warranty, support, indemnity, or liability obligation is offered by
+You alone, and You hereby agree to indemnify every Contributor for any
+liability incurred by such Contributor as a result of warranty, support,
+indemnity or liability terms You offer. You may include additional
+disclaimers of warranty and limitations of liability specific to any
+jurisdiction.
+
+4. Inability to Comply Due to Statute or Regulation
+---------------------------------------------------
+
+If it is impossible for You to comply with any of the terms of this
+License with respect to some or all of the Covered Software due to
+statute, judicial order, or regulation then You must: (a) comply with
+the terms of this License to the maximum extent possible; and (b)
+describe the limitations and the code they affect. Such description must
+be placed in a text file included with all distributions of the Covered
+Software under this License. Except to the extent prohibited by statute
+or regulation, such description must be sufficiently detailed for a
+recipient of ordinary skill to be able to understand it.
+
+5. Termination
+--------------
+
+5.1. The rights granted under this License will terminate automatically
+if You fail to comply with any of its terms. However, if You become
+compliant, then the rights granted under this License from a particular
+Contributor are reinstated (a) provisionally, unless and until such
+Contributor explicitly and finally terminates Your grants, and (b) on an
+ongoing basis, if such Contributor fails to notify You of the
+non-compliance by some reasonable means prior to 60 days after You have
+come back into compliance. Moreover, Your grants from a particular
+Contributor are reinstated on an ongoing basis if such Contributor
+notifies You of the non-compliance by some reasonable means, this is the
+first time You have received notice of non-compliance with this License
+from such Contributor, and You become compliant prior to 30 days after
+Your receipt of the notice.
+
+5.2. If You initiate litigation against any entity by asserting a patent
+infringement claim (excluding declaratory judgment actions,
+counter-claims, and cross-claims) alleging that a Contributor Version
+directly or indirectly infringes any patent, then the rights granted to
+You by any and all Contributors for the Covered Software under Section
+2.1 of this License shall terminate.
+
+5.3. In the event of termination under Sections 5.1 or 5.2 above, all
+end user license agreements (excluding distributors and resellers) which
+have been validly granted by You or Your distributors under this License
+prior to termination shall survive termination.
+
+************************************************************************
+*                                                                      *
+*  6. Disclaimer of Warranty                                           *
+*  -------------------------                                           *
+*                                                                      *
+*  Covered Software is provided under this License on an "as is"       *
+*  basis, without warranty of any kind, either expressed, implied, or  *
+*  statutory, including, without limitation, warranties that the       *
+*  Covered Software is free of defects, merchantable, fit for a        *
+*  particular purpose or non-infringing. The entire risk as to the     *
+*  quality and performance of the Covered Software is with You.        *
+*  Should any Covered Software prove defective in any respect, You     *
+*  (not any Contributor) assume the cost of any necessary servicing,   *
+*  repair, or correction. This disclaimer of warranty constitutes an   *
+*  essential part of this License. No use of any Covered Software is   *
+*  authorized under this License except under this disclaimer.         *
+*                                                                      *
+************************************************************************
+
+************************************************************************
+*                                                                      *
+*  7. Limitation of Liability                                          *
+*  --------------------------                                          *
+*                                                                      *
+*  Under no circumstances and under no legal theory, whether tort      *
+*  (including negligence), contract, or otherwise, shall any           *
+*  Contributor, or anyone who distributes Covered Software as          *
+*  permitted above, be liable to You for any direct, indirect,         *
+*  special, incidental, or consequential damages of any character      *
+*  including, without limitation, damages for lost profits, loss of    *
+*  goodwill, work stoppage, computer failure or malfunction, or any    *
+*  and all other commercial damages or losses, even if such party      *
+*  shall have been informed of the possibility of such damages. This   *
+*  limitation of liability shall not apply to liability for death or   *
+*  personal injury resulting from such party's negligence to the       *
+*  extent applicable law prohibits such limitation. Some               *
+*  jurisdictions do not allow the exclusion or limitation of           *
+*  incidental or consequential damages, so this exclusion and          *
+*  limitation may not apply to You.                                    *
+*                                                                      *
+************************************************************************
+
+8. Litigation
+-------------
+
+Any litigation relating to this License may be brought only in the
+courts of a jurisdiction where the defendant maintains its principal
+place of business and such litigation shall be governed by laws of that
+jurisdiction, without reference to its conflict-of-law provisions.
+Nothing in this Section shall prevent a party's ability to bring
+cross-claims or counter-claims.
+
+9. Miscellaneous
+----------------
+
+This License represents the complete agreement concerning the subject
+matter hereof. If any provision of this License is held to be
+unenforceable, such provision shall be reformed only to the extent
+necessary to make it enforceable. Any law or regulation which provides
+that the language of a contract shall be construed against the drafter
+shall not be used to construe this License against a Contributor.
+
+10. Versions of the License
+---------------------------
+
+10.1. New Versions
+
+Mozilla Foundation is the license steward. Except as provided in Section
+10.3, no one other than the license steward has the right to modify or
+publish new versions of this License. Each version will be given a
+distinguishing version number.
+
+10.2. Effect of New Versions
+
+You may distribute the Covered Software under the terms of the version
+of the License under which You originally received the Covered Software,
+or under the terms of any subsequent version published by the license
+steward.
+
+10.3. Modified Versions
+
+If you create software not governed by this License, and you want to
+create a new license for such software, you may create and use a
+modified version of this License if you rename the license and remove
+any references to the name of the license steward (except to note that
+such modified license differs from this License).
+
+10.4. Distributing Source Code Form that is Incompatible With Secondary
+Licenses
+
+If You choose to distribute Source Code Form that is Incompatible With
+Secondary Licenses under the terms of this version of the License, the
+notice described in Exhibit B of this License must be attached.
+
+Exhibit A - Source Code Form License Notice
+-------------------------------------------
+
+  This Source Code Form is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+If it is not possible or desirable to put the notice in a particular
+file, then You may include the notice in a location (such as a LICENSE
+file in a relevant directory) where a recipient would be likely to look
+for such a notice.
+
+You may add additional accurate notices of copyright ownership.
+
+Exhibit B - "Incompatible With Secondary Licenses" Notice
+---------------------------------------------------------
+
+  This Source Code Form is "Incompatible With Secondary Licenses", as
+  defined by the Mozilla Public License, v. 2.0.

--- a/addons/camel/README.md
+++ b/addons/camel/README.md
@@ -1,0 +1,22 @@
+# SeedStack Camel addon sample
+
+This sample demonstrates how to use Apache Camel addon for Seedstack
+
+## Build
+
+```bash
+mvn clean package
+```
+
+## Run
+
+Execute tests located in `src/test/java` in your IDE, or with Maven:
+
+```bash
+mvn clean verify
+```
+
+## Copyright and license
+
+This source code is copyrighted by [The SeedStack Authors](https://github.com/seedstack/seedstack/blob/master/AUTHORS) and
+released under the terms of the [Mozilla Public License 2.0](https://www.mozilla.org/MPL/2.0/). 

--- a/addons/camel/README.md
+++ b/addons/camel/README.md
@@ -16,6 +16,18 @@ Execute tests located in `src/test/java` in your IDE, or with Maven:
 mvn clean verify
 ```
 
+The integration test gisves an example of how to set a basic Camel route.
+This route copies files from one folder to another using the addon.
+
+## Sample
+
+This sample is a simple web-application exposing a "/person" resource as a Web service.
+Sending a POST request to /person/queue will send a Person object both
+- Through a standard JMS route
+- Through a Camel Managed JMS route
+
+The JSM component, creating the route with a JMS queue is initialized using an implementation of CamelContextInitializer
+
 ## Copyright and license
 
 This source code is copyrighted by [The SeedStack Authors](https://github.com/seedstack/seedstack/blob/master/AUTHORS) and

--- a/addons/camel/pom.xml
+++ b/addons/camel/pom.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright © 2013-2020, The SeedStack authors <http://seedstack.org>
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+-->
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.seedstack.samples</groupId>
+        <artifactId>samples</artifactId>
+        <version>19.11</version>
+        <relativePath>../..</relativePath>
+    </parent>
+
+    <artifactId>camel-sample</artifactId>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.seedstack</groupId>
+                <artifactId>seedstack-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>build-capsule</id>
+                        <goals>
+                            <goal>package</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+    <dependencies>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>${logback.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.seedstack.seed</groupId>
+            <artifactId>seed-testing-junit4</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <!--The Seedstack plugin subject of this sample project-->
+        <dependency>
+            <groupId>org.seedstack.addons.camel</groupId>
+            <artifactId>camel</artifactId>
+            <version>1.0.0-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>2.6</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/addons/camel/pom.xml
+++ b/addons/camel/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>org.seedstack.samples</groupId>
         <artifactId>samples</artifactId>
-        <version>19.11</version>
+        <version>20.7-SNAPSHOT</version>
         <relativePath>../..</relativePath>
     </parent>
 
@@ -39,6 +39,38 @@
     </build>
     <dependencies>
         <dependency>
+            <groupId>org.seedstack.seed</groupId>
+            <artifactId>seed-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.seedstack.seed</groupId>
+            <artifactId>seed-security-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.seedstack.seed</groupId>
+            <artifactId>seed-web-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.seedstack.seed</groupId>
+            <artifactId>seed-web-security</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.seedstack.seed</groupId>
+            <artifactId>seed-rest-jersey2</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.seedstack.seed</groupId>
+            <artifactId>seed-web-undertow</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.seedstack.business</groupId>
+            <artifactId>business-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.seedstack.addons.modelmapper</groupId>
+            <artifactId>modelmapper</artifactId>
+        </dependency>
+        <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
             <version>${logback.version}</version>
@@ -48,11 +80,50 @@
             <artifactId>seed-testing-junit4</artifactId>
             <scope>test</scope>
         </dependency>
+        <!--JMS And active MQ-->
+        <dependency>
+            <groupId>org.seedstack.addons.jms</groupId>
+            <artifactId>jms</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>javax.jms</groupId>
+            <artifactId>jms-api</artifactId>
+            <version>1.1-rev-1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.activemq</groupId>
+            <artifactId>activemq-camel</artifactId>
+            <version>5.15.9</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.activemq</groupId>
+            <artifactId>activemq-broker</artifactId>
+            <version>5.15.9</version>
+        </dependency>
+        <!--
+        <dependency>
+            <groupId>org.apache.activemq</groupId>
+            <artifactId>activemq-core</artifactId>
+            <version>5.7.0</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>commons-logging</groupId>
+                    <artifactId>commons-logging</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        -->
         <!--The Seedstack plugin subject of this sample project-->
         <dependency>
             <groupId>org.seedstack.addons.camel</groupId>
             <artifactId>camel</artifactId>
             <version>1.0.0-SNAPSHOT</version>
+        </dependency>
+        <!--Camel dependencies -->
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-jms</artifactId>
+            <version>3.1.0</version>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>

--- a/addons/camel/pom.xml
+++ b/addons/camel/pom.xml
@@ -21,6 +21,13 @@
 
     <artifactId>camel-sample</artifactId>
 
+    <properties>
+        <camel.version>3.1.0</camel.version>
+        <commons-io.version>2.6</commons-io.version>
+        <activemq.version>5.15.9</activemq.version>
+        <jms-api.version>1.1-rev-1</jms-api.version>
+    </properties>
+
     <build>
         <plugins>
             <plugin>
@@ -75,11 +82,7 @@
             <artifactId>logback-classic</artifactId>
             <version>${logback.version}</version>
         </dependency>
-        <dependency>
-            <groupId>org.seedstack.seed</groupId>
-            <artifactId>seed-testing-junit4</artifactId>
-            <scope>test</scope>
-        </dependency>
+
         <!--JMS And active MQ-->
         <dependency>
             <groupId>org.seedstack.addons.jms</groupId>
@@ -88,47 +91,42 @@
         <dependency>
             <groupId>javax.jms</groupId>
             <artifactId>jms-api</artifactId>
-            <version>1.1-rev-1</version>
+            <version>${jms-api.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.activemq</groupId>
             <artifactId>activemq-camel</artifactId>
-            <version>5.15.9</version>
+            <version>${activemq.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.activemq</groupId>
             <artifactId>activemq-broker</artifactId>
-            <version>5.15.9</version>
+            <version>${activemq.version}</version>
         </dependency>
-        <!--
-        <dependency>
-            <groupId>org.apache.activemq</groupId>
-            <artifactId>activemq-core</artifactId>
-            <version>5.7.0</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>commons-logging</groupId>
-                    <artifactId>commons-logging</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        -->
+
         <!--The Seedstack plugin subject of this sample project-->
         <dependency>
             <groupId>org.seedstack.addons.camel</groupId>
             <artifactId>camel</artifactId>
-            <version>1.0.0-SNAPSHOT</version>
         </dependency>
+
         <!--Camel dependencies -->
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-jms</artifactId>
-            <version>3.1.0</version>
+            <version>${camel.version}</version>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.6</version>
+            <version>${commons-io.version}</version>
+        </dependency>
+
+        <!-- Test dependencies -->
+        <dependency>
+            <groupId>org.seedstack.seed</groupId>
+            <artifactId>seed-testing-junit4</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 </project>

--- a/addons/camel/src/main/java/org/seedstack/samples/camel/application/error/CamelSampleErrorCode.java
+++ b/addons/camel/src/main/java/org/seedstack/samples/camel/application/error/CamelSampleErrorCode.java
@@ -1,0 +1,15 @@
+/*
+ *  Copyright © 2013-2020, The SeedStack authors <http://seedstack.org>
+ *
+ *  This Source Code Form is subject to the terms of the Mozilla Public
+ *   License, v. 2.0. If a copy of the MPL was not distributed with this
+ *   file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package org.seedstack.samples.camel.application.error;
+
+import org.seedstack.shed.exception.ErrorCode;
+
+public enum CamelSampleErrorCode implements ErrorCode {
+    ERR_JMS
+}

--- a/addons/camel/src/main/java/org/seedstack/samples/camel/application/message/MessageService.java
+++ b/addons/camel/src/main/java/org/seedstack/samples/camel/application/message/MessageService.java
@@ -1,0 +1,25 @@
+/*
+ *  Copyright © 2013-2020, The SeedStack authors <http://seedstack.org>
+ *
+ *  This Source Code Form is subject to the terms of the Mozilla Public
+ *   License, v. 2.0. If a copy of the MPL was not distributed with this
+ *   file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package org.seedstack.samples.camel.application.message;
+
+import org.seedstack.business.Service;
+import org.seedstack.samples.camel.domain.model.person.Person;
+
+@Service
+public interface MessageService {
+    public static final String QUEUE_STD_NAME="queue1";
+    public static final String QUEUE_CAMEL_NAME="camelQueue";
+    /**
+     * Sends a person to the Message Queue
+     * @param person the person item to send
+     * @param queueName the queue name
+     */
+    void sendPersonMessage(Person person, String queueName);
+
+}

--- a/addons/camel/src/main/java/org/seedstack/samples/camel/application/message/MessageServiceImpl.java
+++ b/addons/camel/src/main/java/org/seedstack/samples/camel/application/message/MessageServiceImpl.java
@@ -1,0 +1,47 @@
+/*
+ *  Copyright © 2013-2020, The SeedStack authors <http://seedstack.org>
+ *
+ *  This Source Code Form is subject to the terms of the Mozilla Public
+ *   License, v. 2.0. If a copy of the MPL was not distributed with this
+ *   file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package org.seedstack.samples.camel.application.message;
+
+import org.seedstack.jms.JmsConnection;
+import org.seedstack.samples.camel.application.error.CamelSampleErrorCode;
+import org.seedstack.samples.camel.domain.model.person.Person;
+import org.seedstack.seed.Logging;
+import org.seedstack.seed.SeedException;
+import org.seedstack.seed.transaction.Transactional;
+import org.slf4j.Logger;
+
+import javax.inject.Inject;
+import javax.jms.*;
+
+public class MessageServiceImpl implements MessageService {
+
+    @Logging
+    private Logger logger;
+
+    @Inject
+    private Session session;
+
+    @Transactional
+    @JmsConnection("connection1")
+    @Override
+    public void sendPersonMessage(Person person, String queueName) {
+        try {
+            logger.info("Adding person to JMS Queue");
+            Destination queue = session.createQueue(queueName);
+            MessageProducer producer = session.createProducer(queue);
+            ObjectMessage message = session.createObjectMessage();
+            message.setObject(person);
+            producer.send(message);
+        }
+        catch (JMSException jsmE){
+            throw SeedException.wrap(jsmE, CamelSampleErrorCode.ERR_JMS);
+        }
+    }
+
+}

--- a/addons/camel/src/main/java/org/seedstack/samples/camel/application/message/PersonMessageListener.java
+++ b/addons/camel/src/main/java/org/seedstack/samples/camel/application/message/PersonMessageListener.java
@@ -1,0 +1,36 @@
+/*
+ *  Copyright © 2013-2020, The SeedStack authors <http://seedstack.org>
+ *
+ *  This Source Code Form is subject to the terms of the Mozilla Public
+ *   License, v. 2.0. If a copy of the MPL was not distributed with this
+ *   file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package org.seedstack.samples.camel.application.message;
+
+import org.seedstack.jms.JmsMessageListener;
+import org.seedstack.samples.camel.domain.model.person.Person;
+import org.seedstack.seed.Logging;
+import org.slf4j.Logger;
+
+import javax.jms.Message;
+import javax.jms.MessageListener;
+import javax.jms.ObjectMessage;
+
+@JmsMessageListener(connection = "connection1", destinationName = "queue1")
+public class PersonMessageListener implements MessageListener {
+    @Logging
+    private Logger logger;
+
+
+
+    @Override
+    public void onMessage(Message message) {
+        if (message instanceof ObjectMessage) {
+            logger.info("Message received !");
+        } else {
+            logger.warn("Unsupported message type");
+        }
+
+    }
+}

--- a/addons/camel/src/main/java/org/seedstack/samples/camel/application/routes/PersonRouteBuilder.java
+++ b/addons/camel/src/main/java/org/seedstack/samples/camel/application/routes/PersonRouteBuilder.java
@@ -1,0 +1,29 @@
+/*
+ *  Copyright © 2013-2020, The SeedStack authors <http://seedstack.org>
+ *
+ *  This Source Code Form is subject to the terms of the Mozilla Public
+ *   License, v. 2.0. If a copy of the MPL was not distributed with this
+ *   file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package org.seedstack.samples.camel.application.routes;
+
+import org.apache.camel.Processor;
+import org.apache.camel.builder.RouteBuilder;
+import org.seedstack.samples.camel.application.routes.processors.PersonQueueProcessor;
+
+import javax.inject.Inject;
+
+/**
+ * This Camel route uses Camel JMS component to add a person to the repository
+ */
+public class PersonRouteBuilder extends RouteBuilder {
+
+    @Inject
+    private PersonQueueProcessor processor;
+
+    @Override
+    public void configure() throws Exception {
+        from("jmsComponent:queue:camelQueue").process(processor).to("mock:noway");
+    }
+}

--- a/addons/camel/src/main/java/org/seedstack/samples/camel/application/routes/endPoint/AddPersonEndPoint.java
+++ b/addons/camel/src/main/java/org/seedstack/samples/camel/application/routes/endPoint/AddPersonEndPoint.java
@@ -1,0 +1,30 @@
+/*
+ *  Copyright © 2013-2020, The SeedStack authors <http://seedstack.org>
+ *
+ *  This Source Code Form is subject to the terms of the Mozilla Public
+ *   License, v. 2.0. If a copy of the MPL was not distributed with this
+ *   file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package org.seedstack.samples.camel.application.routes.endPoint;
+
+import org.apache.camel.Consumer;
+import org.apache.camel.Endpoint;
+import org.apache.camel.Processor;
+import org.apache.camel.Producer;
+import org.apache.camel.support.DefaultEndpoint;
+import org.seedstack.camel.CamelEndpoint;
+
+@CamelEndpoint(endPointUri = "person:addPerson")
+public class AddPersonEndPoint extends DefaultEndpoint {
+
+    @Override
+    public Producer createProducer() throws Exception {
+        return null;
+    }
+
+    @Override
+    public Consumer createConsumer(Processor processor) throws Exception {
+        return null;
+    }
+}

--- a/addons/camel/src/main/java/org/seedstack/samples/camel/application/routes/initializer/CamelApplicationInitializer.java
+++ b/addons/camel/src/main/java/org/seedstack/samples/camel/application/routes/initializer/CamelApplicationInitializer.java
@@ -1,0 +1,34 @@
+/*
+ *  Copyright © 2013-2020, The SeedStack authors <http://seedstack.org>
+ *
+ *  This Source Code Form is subject to the terms of the Mozilla Public
+ *   License, v. 2.0. If a copy of the MPL was not distributed with this
+ *   file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package org.seedstack.samples.camel.application.routes.initializer;
+
+import org.apache.activemq.ActiveMQConnectionFactory;
+import org.apache.camel.CamelContext;
+import org.apache.camel.component.jms.JmsComponent;
+import org.seedstack.camel.CamelContextInitializer;
+import org.seedstack.jms.spi.JmsFactory;
+import org.seedstack.seed.Logging;
+import org.slf4j.Logger;
+
+import javax.inject.Inject;
+import javax.jms.ConnectionFactory;
+import javax.jms.Session;
+
+public class CamelApplicationInitializer implements CamelContextInitializer {
+
+    @Logging
+    private Logger logger;
+
+    @Override
+    public void initialize(CamelContext camelContext) {
+        logger.info("Camel plugin sample - Initializing camel context");
+        ConnectionFactory connectionFactory = new ActiveMQConnectionFactory("vm://localhost?broker.persistent=false");
+        camelContext.addComponent("jmsComponent", JmsComponent.jmsComponentAutoAcknowledge(connectionFactory));
+    }
+}

--- a/addons/camel/src/main/java/org/seedstack/samples/camel/application/routes/processors/PersonQueueProcessor.java
+++ b/addons/camel/src/main/java/org/seedstack/samples/camel/application/routes/processors/PersonQueueProcessor.java
@@ -1,0 +1,28 @@
+/*
+ *  Copyright © 2013-2020, The SeedStack authors <http://seedstack.org>
+ *
+ *  This Source Code Form is subject to the terms of the Mozilla Public
+ *   License, v. 2.0. If a copy of the MPL was not distributed with this
+ *   file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package org.seedstack.samples.camel.application.routes.processors;
+
+import org.apache.camel.Exchange;
+import org.apache.camel.Processor;
+import org.seedstack.seed.Logging;
+import org.slf4j.Logger;
+
+/**
+ * Camel processor
+ */
+public class PersonQueueProcessor implements Processor {
+
+    @Logging
+    Logger logger;
+
+    @Override
+    public void process(Exchange exchange) throws Exception {
+        logger.info("Exchange treated in processor");
+    }
+}

--- a/addons/camel/src/main/java/org/seedstack/samples/camel/domain/model/person/Person.java
+++ b/addons/camel/src/main/java/org/seedstack/samples/camel/domain/model/person/Person.java
@@ -1,0 +1,47 @@
+/*
+ *  Copyright © 2013-2020, The SeedStack authors <http://seedstack.org>
+ *  
+ *  This Source Code Form is subject to the terms of the Mozilla Public
+ *   License, v. 2.0. If a copy of the MPL was not distributed with this
+ *   file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package org.seedstack.samples.camel.domain.model.person;
+
+import org.seedstack.business.domain.BaseAggregateRoot;
+
+import java.io.Serializable;
+
+public class Person extends BaseAggregateRoot<PersonId> implements Serializable {
+    private final PersonId id;
+    private String firstName;
+    private String lastName;
+
+    public Person(PersonId id) {
+        this.id = id;
+    }
+
+    @Override
+    public PersonId getId() {
+        return id;
+    }
+
+    public String getFirstName() {
+        return firstName;
+    }
+
+    public String getLastName() {
+        return lastName;
+    }
+
+    public void changeName(String firstName, String lastName) {
+        if (firstName == null || firstName.isEmpty()) {
+            throw new IllegalArgumentException("First name is missing");
+        }
+        if (lastName == null || lastName.isEmpty()) {
+            throw new IllegalArgumentException("Last name is missing");
+        }
+        this.firstName = firstName;
+        this.lastName = lastName;
+    }
+}

--- a/addons/camel/src/main/java/org/seedstack/samples/camel/domain/model/person/PersonId.java
+++ b/addons/camel/src/main/java/org/seedstack/samples/camel/domain/model/person/PersonId.java
@@ -1,0 +1,26 @@
+/*
+ *  Copyright © 2013-2020, The SeedStack authors <http://seedstack.org>
+ *
+ *  This Source Code Form is subject to the terms of the Mozilla Public
+ *   License, v. 2.0. If a copy of the MPL was not distributed with this
+ *   file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package org.seedstack.samples.camel.domain.model.person;
+
+import org.seedstack.business.domain.BaseValueObject;
+
+/**
+ * Person value object
+ */
+public class PersonId extends BaseValueObject {
+
+    private final String email;
+    public PersonId(String email) {
+        this.email = email;
+    }
+    public String getEmail() {
+        return email;
+    }
+
+}

--- a/addons/camel/src/main/java/org/seedstack/samples/camel/infrastructure/SampleDataGenerator.java
+++ b/addons/camel/src/main/java/org/seedstack/samples/camel/infrastructure/SampleDataGenerator.java
@@ -1,0 +1,41 @@
+/*
+ *  Copyright © 2013-2020, The SeedStack authors <http://seedstack.org>
+ *
+ *  This Source Code Form is subject to the terms of the Mozilla Public
+ *   License, v. 2.0. If a copy of the MPL was not distributed with this
+ *   file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package org.seedstack.samples.camel.infrastructure;
+
+import javax.inject.Inject;
+
+import org.seedstack.business.domain.Repository;
+import org.seedstack.business.util.inmemory.InMemory;
+import org.seedstack.samples.camel.domain.model.person.Person;
+import org.seedstack.samples.camel.domain.model.person.PersonId;
+import org.seedstack.seed.LifecycleListener;
+import org.seedstack.seed.Logging;
+import org.slf4j.Logger;
+
+public class SampleDataGenerator implements LifecycleListener {
+    @Inject
+    @InMemory
+    private Repository<Person, PersonId> personRepository;
+    @Logging
+    private Logger logger;
+
+    @Override
+    public void started() {
+        logger.info("Adding data to repository");
+        personRepository.addOrUpdate(create("bill.evans@some.org", "Bill", "EVANS"));
+        personRepository.addOrUpdate(create("ella.fitzgerald@some.org", "Ella", "FITZGERALD"));
+        personRepository.addOrUpdate(create("miles.davis@some.org", "Miles", "DAVIS"));
+    }
+
+    private Person create(String email, String firstName, String lastName) {
+        Person person = new Person(new PersonId(email));
+        person.changeName(firstName, lastName);
+        return person;
+    }
+}

--- a/addons/camel/src/main/java/org/seedstack/samples/camel/interfaces/person/AddPersonResponse.java
+++ b/addons/camel/src/main/java/org/seedstack/samples/camel/interfaces/person/AddPersonResponse.java
@@ -1,0 +1,30 @@
+/*
+ *  Copyright © 2013-2020, The SeedStack authors <http://seedstack.org>
+ *
+ *  This Source Code Form is subject to the terms of the Mozilla Public
+ *   License, v. 2.0. If a copy of the MPL was not distributed with this
+ *   file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package org.seedstack.samples.camel.interfaces.person;
+
+/**
+ * Response for adding a person to the repository
+ */
+public class AddPersonResponse {
+    public static final String STATUS_OK="OK";
+    public static final String STATUS_FAIL="Fail";
+
+    private String status;
+
+    public AddPersonResponse(String status){
+        if(!status.equals(STATUS_FAIL) && !(status.equals(STATUS_OK))){
+            throw new IllegalArgumentException("Incorrect status");
+        }
+        this.status=status;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+}

--- a/addons/camel/src/main/java/org/seedstack/samples/camel/interfaces/person/PersonRepresentation.java
+++ b/addons/camel/src/main/java/org/seedstack/samples/camel/interfaces/person/PersonRepresentation.java
@@ -1,0 +1,68 @@
+/*
+ *  Copyright © 2013-2020, The SeedStack authors <http://seedstack.org>
+ *
+ *  This Source Code Form is subject to the terms of the Mozilla Public
+ *   License, v. 2.0. If a copy of the MPL was not distributed with this
+ *   file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package org.seedstack.samples.camel.interfaces.person;
+
+import com.google.common.base.Strings;
+import org.seedstack.samples.camel.domain.model.person.Person;
+import org.seedstack.samples.camel.domain.model.person.PersonId;
+
+/**
+ * Represents a person
+ */
+public class PersonRepresentation {
+    private String mail;
+    private String firstName;
+    private String lastName;
+
+    public PersonRepresentation(Person person){
+        this.mail= person.getId().getEmail();
+        this.firstName=person.getFirstName();
+        this.lastName=person.getLastName();
+    }
+
+    /**
+     * Empty constructor
+     */
+    public PersonRepresentation(){
+    }
+
+    public Person asPerson(){
+        if(Strings.isNullOrEmpty(mail) || Strings.isNullOrEmpty(firstName) || Strings.isNullOrEmpty(lastName)){
+            throw new UnsupportedOperationException("Person fields are missing");
+        }
+        PersonId identifier = new PersonId(mail);
+        Person person = new Person(identifier);
+        person.changeName(firstName, lastName);
+        return person;
+    }
+
+    public void setMail(String mail) {
+        this.mail = mail;
+    }
+
+    public void setFirstName(String firstName) {
+        this.firstName = firstName;
+    }
+
+    public void setLastName(String lastName) {
+        this.lastName = lastName;
+    }
+
+    public String getMail() {
+        return mail;
+    }
+
+    public String getFirstName() {
+        return firstName;
+    }
+
+    public String getLastName() {
+        return lastName;
+    }
+}

--- a/addons/camel/src/main/java/org/seedstack/samples/camel/interfaces/person/PersonResource.java
+++ b/addons/camel/src/main/java/org/seedstack/samples/camel/interfaces/person/PersonResource.java
@@ -1,0 +1,80 @@
+/*
+ *  Copyright © 2013-2020, The SeedStack authors <http://seedstack.org>
+ *
+ *  This Source Code Form is subject to the terms of the Mozilla Public
+ *   License, v. 2.0. If a copy of the MPL was not distributed with this
+ *   file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package org.seedstack.samples.camel.interfaces.person;
+
+import org.seedstack.business.domain.Repository;
+import org.seedstack.business.specification.Specification;
+import org.seedstack.business.util.inmemory.InMemory;
+import org.seedstack.samples.camel.application.message.MessageService;
+import org.seedstack.samples.camel.application.message.MessageServiceImpl;
+import org.seedstack.samples.camel.domain.model.person.Person;
+import org.seedstack.samples.camel.domain.model.person.PersonId;
+import org.seedstack.seed.SeedException;
+
+import javax.inject.Inject;
+import javax.ws.rs.*;
+import javax.ws.rs.core.MediaType;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * person resources - provides an API for Person
+ */
+@Path("person")
+public class PersonResource {
+
+    @Inject
+    @InMemory
+    private Repository<Person, PersonId> personRepository;
+    @Inject
+    private MessageService messageService;
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    public List<PersonRepresentation> getFullPersonList(){
+        List<PersonRepresentation> finalList= new ArrayList<>();
+        personRepository.get(getAllPersonSpecification()).forEach(person -> {
+            finalList.add(new PersonRepresentation(person));
+        });
+        return finalList;
+    }
+
+    @POST
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public AddPersonResponse addPerson(PersonRepresentation personRepresentation){
+        try {
+            personRepository.addOrUpdate(personRepresentation.asPerson());
+            return new AddPersonResponse(AddPersonResponse.STATUS_OK);
+        }
+        catch (Exception e){
+            return new AddPersonResponse(AddPersonResponse.STATUS_FAIL);
+        }
+    }
+
+    @POST
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    @Path("/queue")
+    public AddPersonResponse messageAddPerson(PersonRepresentation personRepresentation){
+        try {
+            messageService.sendPersonMessage(personRepresentation.asPerson(), MessageService.QUEUE_STD_NAME);
+            messageService.sendPersonMessage(personRepresentation.asPerson(), MessageService.QUEUE_CAMEL_NAME);
+            return new AddPersonResponse(AddPersonResponse.STATUS_OK);
+        }
+        catch(Exception e){
+            return new AddPersonResponse(AddPersonResponse.STATUS_FAIL);
+        }
+    }
+
+    private Specification<Person> getAllPersonSpecification(){
+        return personRepository.getSpecificationBuilder().of(Person.class).all().build();
+    }
+}

--- a/addons/camel/src/main/java/org/seedstack/samples/camel/routes/FileCopyRouteBuilder.java
+++ b/addons/camel/src/main/java/org/seedstack/samples/camel/routes/FileCopyRouteBuilder.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright © 2013-2020, The SeedStack authors <http://seedstack.org>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.seedstack.samples.camel.routes;
+
+import org.apache.camel.builder.RouteBuilder;
+import org.seedstack.seed.Configuration;
+
+public class FileCopyRouteBuilder extends RouteBuilder {
+
+    @Configuration("sample.route.from")
+    private String origin;
+    @Configuration("sample.route.to")
+    private String destination;
+
+    @Override
+    public void configure() throws Exception {
+        from(origin).to(destination);
+    }
+}

--- a/addons/camel/src/main/java/org/seedstack/samples/camel/routes/FileCopyRouteBuilder.java
+++ b/addons/camel/src/main/java/org/seedstack/samples/camel/routes/FileCopyRouteBuilder.java
@@ -12,9 +12,9 @@ import org.seedstack.seed.Configuration;
 
 public class FileCopyRouteBuilder extends RouteBuilder {
 
-    @Configuration("sample.route.from")
+    @Configuration("sample.routeFc.from")
     private String origin;
-    @Configuration("sample.route.to")
+    @Configuration("sample.routeFc.to")
     private String destination;
 
     @Override

--- a/addons/camel/src/main/resources/META-INF/errors/com.inetpsa.svr.application.exceptions.codes.GitHubLicenCingErrorCode.properties
+++ b/addons/camel/src/main/resources/META-INF/errors/com.inetpsa.svr.application.exceptions.codes.GitHubLicenCingErrorCode.properties
@@ -1,0 +1,2 @@
+ERR_JMS.message = JMS sending/receiving failure
+ERR_JMS.fix = Check your JSM configuration

--- a/addons/camel/src/main/resources/META-INF/resources/index.html
+++ b/addons/camel/src/main/resources/META-INF/resources/index.html
@@ -1,0 +1,13 @@
+<!--
+  ~  Copyright © 2013-2020, The SeedStack authors <http://seedstack.org>
+  ~
+  ~  This Source Code Form is subject to the terms of the Mozilla Public
+  ~   License, v. 2.0. If a copy of the MPL was not distributed with this
+  ~   file, You can obtain one at http://mozilla.org/MPL/2.0/.
+  -->
+
+<html>
+<body>
+This is the Seedstack camel addon sample
+</body>
+</html>

--- a/addons/camel/src/main/resources/application.yaml
+++ b/addons/camel/src/main/resources/application.yaml
@@ -1,0 +1,29 @@
+application:
+  id: camel-sample
+  basePackages : org.seedstack.samples.camel
+
+web :
+  server:
+    port: 80
+  static:
+    enabled: true
+
+sample:
+  folder:
+    tempFolder: ${sys.java\.io\.tmpdir}/Camel
+    origin: ${sample.folder.tempFolder}/inbox
+    destination: ${sample.folder.tempFolder}/outbox
+  routeFc:
+    from: file:${sample.folder.origin}?noop=true
+    to: file:${sample.folder.destination}
+
+jms:
+  connectionFactories:
+    connectionFactory1:
+      vendorClass: org.apache.activemq.ActiveMQConnectionFactory
+      vendorProperties:
+        brokerURL: vm://localhost?broker.persistent=false
+  connections:
+    connection1:
+      connectionFactory: connectionFactory1
+      reconnectionDelay: 50

--- a/addons/camel/src/test/java/org/seedstack/samples/camel/FileCopyRouteIT.java
+++ b/addons/camel/src/test/java/org/seedstack/samples/camel/FileCopyRouteIT.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright © 2013-2020, The SeedStack authors <http://seedstack.org>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.seedstack.samples.camel;
+
+import org.apache.commons.io.FileUtils;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.seedstack.seed.Configuration;
+import org.seedstack.seed.Logging;
+import org.seedstack.seed.testing.junit4.SeedITRunner;
+import org.slf4j.Logger;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.Charset;
+
+@RunWith(SeedITRunner.class)
+public class FileCopyRouteIT {
+    private static final String DATA_CONTENT="Camel Addon data content";
+    @Logging
+    private Logger logger;
+
+    @Configuration("sample.folder.origin")
+    private File originFolder;
+    @Configuration("sample.folder.destination")
+    private File destinationFolder;
+
+    @Rule
+    public TemporaryFolder tempFolder = new TemporaryFolder();
+
+    /**
+     * The file copy route is defined in {@link org.seedstack.samples.camel.routes.FileCopyRouteBuilder}
+     * and parametrized with configuration values.
+     * Seedstack adds this route builder to the Camel context and starts it.<br>
+     * <br>
+     * This test copies a file to the origin folder and check that a copy of this file is present in the destination folder
+     */
+    @Test
+    public void testFileCopyRoute() throws IOException, InterruptedException {
+        cleanTestDirectories();
+        File dataFile=createAndFillDataFile();
+
+        try {
+            //Copy the file to the origin folder
+            logger.info("Copying file to the origin folder");
+            FileUtils.copyFileToDirectory(dataFile, originFolder);
+            //Wait a little for the Camel route to proceed its behaviour
+            Thread.sleep(1000);
+            File copiedFile = FileUtils.getFile(destinationFolder, dataFile.getName());
+            Assert.assertTrue("The destination file does not exist", copiedFile.exists());
+            logger.info("The file is copied to the destination folder");
+            Assert.assertTrue("The data of origin and destination files do not match !", FileUtils.contentEquals(dataFile, copiedFile));
+            logger.info("The file content has been copied");
+        }
+        finally {
+            cleanTestDirectories();
+        }
+    }
+    private File createAndFillDataFile(){
+        logger.info("Creating data file");
+        String fileName="CamelFileRouteData"+System.currentTimeMillis();
+        File dataFile=null;
+        try {
+            dataFile=tempFolder.newFile(fileName);
+            FileUtils.write(dataFile, DATA_CONTENT, Charset.defaultCharset());
+        }
+        catch (IOException ioe){
+            Assert.fail("IOException while creating and filling data file");
+        }
+        return dataFile;
+    }
+
+    private void cleanTestDirectories(){
+        logger.info("Cleaning test directories");
+        try {
+            FileUtils.cleanDirectory(originFolder);
+            FileUtils.cleanDirectory(destinationFolder);
+        }
+        catch(IOException ioe){
+            Assert.fail("IOException while cleaning test directories");
+        }
+    }
+}

--- a/addons/camel/src/test/java/org/seedstack/samples/camel/FileCopyRouteIT.java
+++ b/addons/camel/src/test/java/org/seedstack/samples/camel/FileCopyRouteIT.java
@@ -21,6 +21,7 @@ import org.slf4j.Logger;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.Charset;
+import java.nio.file.Files;
 
 @RunWith(SeedITRunner.class)
 public class FileCopyRouteIT {
@@ -32,9 +33,12 @@ public class FileCopyRouteIT {
     private File originFolder;
     @Configuration("sample.folder.destination")
     private File destinationFolder;
+    @Configuration("sample.folder.tempFolder")
+    private File rootTemporaryFolder;
 
     @Rule
     public TemporaryFolder tempFolder = new TemporaryFolder();
+
 
     /**
      * The file copy route is defined in {@link org.seedstack.samples.camel.routes.FileCopyRouteBuilder}
@@ -45,6 +49,7 @@ public class FileCopyRouteIT {
      */
     @Test
     public void testFileCopyRoute() throws IOException, InterruptedException {
+        logger.info("SMO test : {}", System.getProperty("java.io.tmpdir"));
         cleanTestDirectories();
         File dataFile=createAndFillDataFile();
 
@@ -62,6 +67,7 @@ public class FileCopyRouteIT {
         }
         finally {
             cleanTestDirectories();
+            deleteTempDirs();
         }
     }
     private File createAndFillDataFile(){
@@ -79,13 +85,28 @@ public class FileCopyRouteIT {
     }
 
     private void cleanTestDirectories(){
-        logger.info("Cleaning test directories");
         try {
+        //Preparing test dirs
+        if(!originFolder.exists()){
+            Files.createDirectories(originFolder.toPath());
+        }
+        if(!destinationFolder.exists()){
+                Files.createDirectories(destinationFolder.toPath());
+            }
+        logger.info("Cleaning test directories");
             FileUtils.cleanDirectory(originFolder);
             FileUtils.cleanDirectory(destinationFolder);
         }
         catch(IOException ioe){
             Assert.fail("IOException while cleaning test directories");
+        }
+    }
+
+    private void deleteTempDirs(){
+        try {
+            FileUtils.deleteDirectory(rootTemporaryFolder);
+        } catch (IOException e) {
+            logger.warn("Unable to delete directory : {} : {}"+rootTemporaryFolder.getPath(),e);
         }
     }
 }

--- a/addons/camel/src/test/resources/application.yaml
+++ b/addons/camel/src/test/resources/application.yaml
@@ -1,0 +1,15 @@
+#
+# Copyright © 2013-2020, The SeedStack authors <http://seedstack.org>
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+
+sample:
+  folder:
+    origin: /TEMP/Camel/inbox
+    destination: /TEMP/Camel/outbox
+  route:
+    from: file:${sample.folder.origin}?noop=true
+    to: file:${sample.folder.destination}

--- a/addons/camel/src/test/resources/application.yaml
+++ b/addons/camel/src/test/resources/application.yaml
@@ -8,8 +8,9 @@
 
 sample:
   folder:
-    origin: /TEMP/Camel/inbox
-    destination: /TEMP/Camel/outbox
+    tempFolder: ${sys.java\.io\.tmpdir}/Camel
+    origin: ${sample.folder.tempFolder}/inbox
+    destination: ${sample.folder.tempFolder}/outbox
   route:
     from: file:${sample.folder.origin}?noop=true
     to: file:${sample.folder.destination}

--- a/basics/business/pom.xml
+++ b/basics/business/pom.xml
@@ -29,6 +29,7 @@
         <dependency>
             <groupId>org.seedstack.business</groupId>
             <artifactId>business-core</artifactId>
+            <version>4.3.2-SNAPSHOT</version>
         </dependency>
 
         <dependency>

--- a/basics/business/pom.xml
+++ b/basics/business/pom.xml
@@ -29,7 +29,6 @@
         <dependency>
             <groupId>org.seedstack.business</groupId>
             <artifactId>business-core</artifactId>
-            <version>4.3.2-SNAPSHOT</version>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -93,6 +93,7 @@
         <module>addons/spring-bridge</module>
         <module>addons/w20-bridge</module>
         <module>addons/web-services</module>
+        <module>addons/camel</module>
         <module>full-apps/catalog-microservice</module>
         <module>full-apps/ddd</module>
         <module>full-apps/store-webapp</module>


### PR DESCRIPTION
Adds the Camel addon sample.
This sample consists of :
- An integration test for showing basic usage of Camel add-on  : creates a route between two folders copying files from one to another.
- A simple Web application exposing a webService : a POST request to this web service will send a message to a JSM Queue using Camel. This exemple shows how to initialize a JMS component for Camel, and use it within a route.

This PR also updates versions in poms for 20.7-SNAPSHOT usage